### PR TITLE
 feat :  form-builder在组件值发生变化时触发事件，供父组件监听。

### DIFF
--- a/packages/form-designer-core/src/components/formBuilder.vue
+++ b/packages/form-designer-core/src/components/formBuilder.vue
@@ -114,6 +114,10 @@ export default {
     disabled: {
       type: Boolean,
       default: false
+    },
+    valChange:{
+      type: Function,
+      default:null
     }
   },
   components: {
@@ -155,6 +159,8 @@ export default {
   methods: {
     handlerValChange(key, origin) {
       this.form[key] = origin
+      //向父组件触发一个事件，父组件监听该事件
+      this.$emit("valChange",key,origin)
     },
     handlerDynamicValChange(parentId, index, key, origin) {
       this.$set(this.form[parentId][index], key, origin)


### PR DESCRIPTION
### Satisfy listening events of value changes  when using form-builder components.

`<form-builder ref="myForm" @val-change="valChange" v-model="myValue" :build-data="formVal"></form-builder>`

...

`
const valChange = (key: string, origin: any) => {
  console.log("====", key, origin);
};
`